### PR TITLE
Create Prompts for "End Date" is greater than the "Start Date"

### DIFF
--- a/Prompts for "End Date" is greater than the "Start Date"
+++ b/Prompts for "End Date" is greater than the "Start Date"
@@ -1,0 +1,75 @@
+To implement logic that ensures the "End Date" is greater than the "Start Date" in ServiceNow, you can create a validation using a Client Script or Business Rule, depending on where the validation needs to occur (on the form or when the record is saved).
+
+Example 1: Client-Side Validation (Client Script)
+
+Here’s an example of a prompt you can use to generate the necessary code in ServiceNow for validating that the "End Date" is greater than the "Start Date":
+
+Prompt:
+
+"Generate a client script for a form in ServiceNow that ensures the 'End Date' field is greater than the 'Start Date' field and shows an error message if the validation fails."
+
+Generated Response (Client Script Code):
+
+// Client Script (Type: onSubmit or onChange)
+function onSubmit() {
+    var startDate = g_form.getValue('start_date');  // Replace 'start_date' with your field name
+    var endDate = g_form.getValue('end_date');      // Replace 'end_date' with your field name
+
+    // Convert the dates to Date objects
+    var start = new Date(startDate);
+    var end = new Date(endDate);
+
+    // Validate that the End Date is greater than the Start Date
+    if (end <= start) {
+        g_form.showFieldMsg('end_date', 'End Date must be greater than Start Date', 'error');  // Show error message
+        return false;  // Prevent form submission
+    }
+
+    return true;  // Allow form submission if validation passes
+}
+
+Explanation:
+
+onSubmit Client Script: This script runs when the user submits the form. It ensures that the "End Date" is greater than the "Start Date."
+
+g_form.getValue(): Retrieves the values of the "Start Date" and "End Date" fields.
+
+Date comparison: The script converts the field values into Date objects and checks if the "End Date" is less than or equal to the "Start Date."
+
+g_form.showFieldMsg(): If the validation fails, an error message is displayed next to the "End Date" field, and form submission is prevented.
+
+
+
+---
+
+Example 2: Server-Side Validation (Business Rule)
+
+If you want to enforce the validation on the server side, you can use a Business Rule.
+
+Prompt:
+
+"Generate a Business Rule for ServiceNow that validates if the 'End Date' field is greater than the 'Start Date' field before allowing the record to be saved."
+
+Generated Response (Business Rule Code):
+
+// Business Rule (Type: Before Insert/Update)
+if (current.end_date && current.start_date) {
+    var startDate = new GlideDateTime(current.start_date);
+    var endDate = new GlideDateTime(current.end_date);
+
+    // Check if End Date is greater than Start Date
+    if (endDate.getNumericValue() <= startDate.getNumericValue()) {
+        gs.addErrorMessage('End Date must be greater than Start Date.');
+        current.setAbortAction(true);  // Prevents the record from being saved
+    }
+}
+
+Explanation:
+
+Before Insert/Update Business Rule: This rule runs before the record is inserted or updated in the database, ensuring that the "End Date" is greater than the "Start Date."
+
+GlideDateTime: Used to compare dates in ServiceNow.
+
+current.setAbortAction(true): Stops the record from being saved if the validation fails.
+
+gs.addErrorMessage(): Displays an error message to the user.


### PR DESCRIPTION
To implement logic that ensures the "End Date" is greater than the "Start Date" in ServiceNow, you can create a validation using a Client Script or Business Rule, depending on where the validation needs to occur (on the form or when the record is saved).